### PR TITLE
Remove trailing whitespace

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,7 +17,7 @@ You are always permitted to make arrangements wholly outside of this
 license directly with the Copyright Holder of a given Package.  If the
 terms of this license do not permit the full use that you propose to
 make of the Package, you should contact the Copyright Holder and seek
-a different licensing arrangement. 
+a different licensing arrangement.
 
 Definitions
 
@@ -50,7 +50,7 @@ Definitions
 
     "Modified Version" means the Package, if it has been changed, and
     such changes were not explicitly requested by the Copyright
-    Holder. 
+    Holder.
 
     "Original License" means this Artistic License as Distributed with
     the Standard Version of the Package, in its current version or as
@@ -86,7 +86,7 @@ Package will still be considered the Standard Version, and as such
 will be subject to the Original License.
 
 
-Distribution of Modified Versions of the Package as Source 
+Distribution of Modified Versions of the Package as Source
 
 (4)  You may Distribute your Modified Version as Source (either gratis
 or for a Distributor Fee, and with or without a Compiled form of the
@@ -108,7 +108,7 @@ you do at least ONE of the following:
     (c)  allow anyone who receives a copy of the Modified Version to
     make the Source form of the Modified Version available to others
     under
-		
+
 	(i)  the Original License or
 
 	(ii)  a license that permits the licensee to freely copy,
@@ -120,7 +120,7 @@ you do at least ONE of the following:
 	Fees are allowed.
 
 
-Distribution of Compiled Forms of the Standard Version 
+Distribution of Compiled Forms of the Standard Version
 or Modified Versions without the Source
 
 (5)  You may Distribute Compiled forms of the Standard Version without
@@ -138,7 +138,7 @@ the Source, provided that you comply with Section 4 with respect to
 the Source of the Modified Version.
 
 
-Aggregating or Linking the Package 
+Aggregating or Linking the Package
 
 (7)  You may aggregate the Package (either the Standard Version or
 Modified Version) with other packages and Distribute the resulting
@@ -155,7 +155,7 @@ include the Package, and Distribute the result without restriction,
 provided the result does not expose a direct interface to the Package.
 
 
-Items That are Not Considered Part of a Modified Version 
+Items That are Not Considered Part of a Modified Version
 
 (9) Works (including, but not limited to, modules and scripts) that
 merely extend or make use of the Package, do not, by themselves, cause

--- a/docs/Language/cli.pod6
+++ b/docs/Language/cli.pod6
@@ -13,8 +13,8 @@ It lets you customize the generation process with restrictions.
 =head2 X<documentable setup>
 
 Download template files in your current working directory. You can check them
-L<here|https://github.com/Raku/Documentable/releases/tag/v1.0.1>. B<You do not 
-need to use these exact files>. You can modify them as you want, but take 
+L<here|https://github.com/Raku/Documentable/releases/tag/v1.0.1>. B<You do not
+need to use these exact files>. You can modify them as you want, but take
 special care with the placeholders in C<main.mustache>.
 
 =head2 X<documentable start>
@@ -23,7 +23,7 @@ Start the HTML generation process.
 
 =head2 X<documentable update>
 
-Update the HTML files using the latest changes from the pod collection, B<without> 
+Update the HTML files using the latest changes from the pod collection, B<without>
 regenerate each and every file.
 
 =head2 X<documentable clean>
@@ -151,7 +151,7 @@ The C<title-page> will be the main headline of that page; C<pod-root-path>
 will point to the default URL, and will be used mainly for substitution
 within pages; C<kinds> are menus that will be inserted as part of the header,
 every C<kind> will be a menu button. The C<categories> section is used to
-generate different sub-menus in the header. The C<sort> key tells C<Documentable> 
+generate different sub-menus in the header. The C<sort> key tells C<Documentable>
 to sort that specific page.
 
 =head2 X<-v, --verbose>
@@ -252,7 +252,7 @@ Version of C<Documentable>.
 
 =head1 Examples
 
-If you only want to process your pod collection to check the pod files syntax. 
+If you only want to process your pod collection to check the pod files syntax.
 You can execute:
 
 =begin code

--- a/docs/Language/highlighting.pod6
+++ b/docs/Language/highlighting.pod6
@@ -4,7 +4,7 @@
 
 =SUBTITLE Highlighting the code blocks
 
-Developing a good highlighter for Raku is hard, so there is not a lot available to 
+Developing a good highlighter for Raku is hard, so there is not a lot available to
 choose from. We are using L<atom-language-perl6|https://github.com/perl6/atom-language-perl6>
 developed by L<@samcv|https://github.com/samcv>.
 

--- a/docs/Language/typegraph.pod6
+++ b/docs/Language/typegraph.pod6
@@ -10,7 +10,7 @@ L<TypeGraph|https://github.com/antoniogamiz/Perl6-TypeGraph>.
 =head2 TypeGraph file
 
 At this moment, L<TypeGraph|https://github.com/antoniogamiz/Perl6-TypeGraph> is not able
-to automatically detect the hierarchy of a documented class, so you need to provide this 
+to automatically detect the hierarchy of a documented class, so you need to provide this
 information in a file. There's two options to specify this file:
 
 =item Use the C<--typegraph-file> to specify a custom path.

--- a/docs/Type/Documentable/Heading/Grammar.pod6
+++ b/docs/Type/Documentable/Heading/Grammar.pod6
@@ -7,7 +7,7 @@
 
     grammar Documentable::Heading::Grammar
 
-Used to extract the necessary metadata from headings elements. It extracts four 
+Used to extract the necessary metadata from headings elements. It extracts four
 different values from a heading:
 
 =item1 C<name>.

--- a/docs/Type/Documentable/Index.pod6
+++ b/docs/Type/Documentable/Index.pod6
@@ -26,7 +26,7 @@ Defined as
 
     method meta(--> Array[Str])
 
-Returns the meta part corresponding to the reference. You need to have in mind how 
+Returns the meta part corresponding to the reference. You need to have in mind how
 the meta part is parsed. Given the following reference element:
 
 =begin pod

--- a/docs/Type/Documentable/Registry.pod6
+++ b/docs/Type/Documentable/Registry.pod6
@@ -8,7 +8,7 @@
     class Documentable::Registry {}
 
 An instance of this object is used to deal with a collection of L<Documentable|/type/Documentable>
-objects. It gives you an API to access all the processed documentation. We can say this class is 
+objects. It gives you an API to access all the processed documentation. We can say this class is
 our source of information.
 
 =head1 Methods

--- a/lib/Documentable/CLI.pm6
+++ b/lib/Documentable/CLI.pm6
@@ -31,7 +31,7 @@ package Documentable::CLI {
     }
 
     our proto MAIN(|) is export { * }
-    
+
     multi MAIN() {
         say 'Execute "documentable --help" for more information.';
     }
@@ -44,7 +44,7 @@ package Documentable::CLI {
         DEBUG("Setting up the directory...");
 
         constant $assetsDIR = "documentable-assets";
-        constant $assetsURL = "https://github.com/Raku/Documentable/releases/download/v1.0.1/{$assetsDIR}.tar.gz"; 
+        constant $assetsURL = "https://github.com/Raku/Documentable/releases/download/v1.0.1/{$assetsDIR}.tar.gz";
 
         shell "curl -Ls {$assetsURL} --output {$assetsDIR}.tar.gz";
         shell "tar -xzf {$assetsDIR}.tar.gz";
@@ -53,7 +53,7 @@ package Documentable::CLI {
         my @assets-files = list-files($assetsDIR).map({.relative($assetsDIR).IO});
         my @no-duplicated-files = @assets-files.grep({! .e});
         my @duplicated-files = @assets-files.grep({.e});
-       
+
         for @duplicated-files -> $file {
             note colored("[WARNING] $file will be overriden by this operation", 'yellow');
         }
@@ -85,15 +85,15 @@ package Documentable::CLI {
         DEBUG("Cleaning up the directory...");
 
         constant @files-to-delete = (
-            "Makefile", 
-            "app.pl", 
-            "app-start", 
+            "Makefile",
+            "app.pl",
+            "app-start",
             "documentable.json"
         );
         unlink(@files-to-delete);
 
         constant @dirs-to-delete = (
-            "html", 
+            "html",
             "highlights",
             "assets",
             "templates"

--- a/lib/Documentable/To/HTML/Wrapper.pm6
+++ b/lib/Documentable/To/HTML/Wrapper.pm6
@@ -17,9 +17,9 @@ submethod BUILD(
     if ($!config.url-prefix) {
         $!prefix  = $!config.url-prefix;
         &!rewrite = &rewrite-url.assuming(*, $!prefix);
-    } 
+    }
 }
- 
+
 method generate-menu-entries($selected) {
     my @menu-entries = $!config.kinds;
     @menu-entries .= map( -> $kind {
@@ -63,7 +63,7 @@ method generate-source-url($pod-path is copy) {
     $pod-path .= subst($trailing-slash, '');
     my $source-url = "{$.config.pod-root-path}/{$pod-path.tc}";
     $source-url .= subst(:g, '::', '/');
-    
+
     my Regex $has-file-extension = /\.pod6$/;
     return $source-url if $source-url ~~ $has-file-extension;
     return "{$source-url}.pod6";

--- a/resources/templates/main.mustache
+++ b/resources/templates/main.mustache
@@ -32,10 +32,10 @@
                 Not in Index (<a href="" id="try-web-search">try site search</a>)
             </p>
         </div>
-        
+
         {{! Site navigation menus }}
         <div class="menu">
-            
+
             {{! Main menu }}
             <div class="menu-items dark-green">
                 <a class='menu-item darker-green' href='https://raku.org'><strong>Raku homepage</strong></a>
@@ -43,21 +43,21 @@
                     <a class="menu-item {{{class}}}" href="{{{href}}}"> {{{displayText}}} </a>
                 {{/menuEntries}}
             </div>
-            
+
             {{! Submenu }}
             {{#submenuEntries}}<div class="menu-items darker-green">{{/submenuEntries}}
                 {{#submenuEntries}}
                     <a class="menu-item" href="{{{href}}}"> {{{display-text}}} </a>
                 {{/submenuEntries}}
             {{#submenuEntries}}</div>{{/submenuEntries}}
-        
+
         </div>
     </div>
 
     {{! ============= main content ============= }}
     <div id="content" class="pretty-box yellow content_fragment">
 
-        
+
         {{! edit button }}
         {{#editable}}
             <div align="right">

--- a/t/102-update.t
+++ b/t/102-update.t
@@ -8,7 +8,7 @@ plan *;
 subtest 'update option' => {
     # create the cache
     Documentable::CLI::MAIN(
-        'start', 
+        'start',
         :topdir('./t/test-doc'),
         :typegraph-file("t/test-doc/type-graph.txt"),
         :!verbose

--- a/testing.Dockerfile
+++ b/testing.Dockerfile
@@ -2,7 +2,7 @@ FROM jjmerelo/raku-test-circleci
 
 LABEL version="1.0.0" maintainer="Antonio Gamiz <antoniogamiz10@gmail.com>"
 
-RUN apk add graphviz 
+RUN apk add graphviz
 RUN apk add  --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.7/main/ nodejs=8.9.3-r1
 
 COPY resources/highlights /highlights
@@ -11,7 +11,7 @@ RUN apk add --no-cache --virtual .gyp python make g++ \
     && cd /highlights \
     && git clone https://github.com/perl6/atom-language-perl6 \
     && npm install . \
-    && apk del .gyp \ 
+    && apk del .gyp \
     && cd ..
 
 RUN npm install -g sass


### PR DESCRIPTION
Some projects consider this a must, and will disallow commits to be submitted which contain trailing whitespace (the Linux kernel is an example project where trailing whitespace isn't permitted).  Other projects see whitespace cleanup as simply nit-picking.  Either way, I thought I'd bring it to your attention and fix the issue just in case you'd like it to be fixed.

This PR is submitted in the hope that it is useful.  If you would like anything changed, please just let me know and I'll be happy to update and resubmit as necessary.