### PR TITLE
Replace wget -> curl in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ the `sass` command
     $ sudo apt-get install ruby-sass
 ```
 
-#### wget and tar
+#### curl and tar
 
 These programs are used by `documentable setup` to download the default assets
 and extract them. If you are on Ubuntu/Debian you will not have any problem (probably). If you are using Windows I recommend you to download the assets yourself from [this link](https://github.com/raku/Documentable/releases/download/v1.0.1/assets.tar.gz).


### PR DESCRIPTION
Because this is the program used in the internals to download the
documentable assets file.