### PR TITLE
Fix link to documentable assets tarball in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ the `sass` command
 #### wget and tar
 
 These programs are used by `documentable setup` to download the default assets
-and extract them. If you are on Ubuntu/Debian you will not have any problem (probably). If you are using Windows I recommend you to download the assets yourself from [this link](https://github.com/raku/Documentable/releases/download/v1.0.1/assets.tar.gz).
+and extract them. If you are on Ubuntu/Debian you will not have any problem (probably). If you are using Windows I recommend you to download the assets yourself from [this link](https://github.com/raku/Documentable/releases/download/v1.0.1/documentable-assets.tar.gz).
 
 ## FAQ
 


### PR DESCRIPTION
This should make it easier for readers of the README to select the
correct file to download should they need to do so.