### PR TITLE
Fix name of `template` directory

### DIFF
--- a/lib/Documentable/CLI.pm6
+++ b/lib/Documentable/CLI.pm6
@@ -96,7 +96,7 @@ package Documentable::CLI {
             "html",
             "highlights",
             "assets",
-            "templates"
+            "template"
         );
         @dirs-to-delete.map({rmtree($_)});
     }
@@ -120,9 +120,9 @@ package Documentable::CLI {
         Bool :a(:$all)             = False                    #= Equivalent to -t -p -s -i --search-index
     ) {
         my $beginning = now; # to measure total time
-        if (!"./html".IO.e || !"./assets".IO.e || !"./templates".IO.e and $v) {
+        if (!"./html".IO.e || !"./assets".IO.e || !"./template".IO.e and $v) {
             note q:to/END/;
-                (warning) html and/or assets and/or templates directories
+                (warning) html and/or assets and/or template directories
                 cannot be found. You can get the defaults by executing:
 
                     documentable setup

--- a/lib/Documentable/CLI.pm6
+++ b/lib/Documentable/CLI.pm6
@@ -25,6 +25,13 @@ class X::Documentable::NodeNotFound is Exception {
 
 package Documentable::CLI {
 
+    constant @default-asset-dirs = (
+        "html",
+        "highlights",
+        "assets",
+        "template",
+    );
+
     sub RUN-MAIN(|c) is export {
         my %*SUB-MAIN-OPTS = :named-anywhere;
         CORE::<&RUN-MAIN>(|c)
@@ -92,13 +99,7 @@ package Documentable::CLI {
         );
         unlink(@files-to-delete);
 
-        constant @dirs-to-delete = (
-            "html",
-            "highlights",
-            "assets",
-            "template"
-        );
-        @dirs-to-delete.map({rmtree($_)});
+        @default-asset-dirs.map({rmtree($_)});
     }
 
     #| Start the documentation generation with the specified options
@@ -120,10 +121,14 @@ package Documentable::CLI {
         Bool :a(:$all)             = False                    #= Equivalent to -t -p -s -i --search-index
     ) {
         my $beginning = now; # to measure total time
-        if (!"./html".IO.e || !"./assets".IO.e || !"./template".IO.e and $v) {
-            note q:to/END/;
-                (warning) html and/or assets and/or template directories
-                cannot be found. You can get the defaults by executing:
+        my $asset-dir-missing = @default-asset-dirs.map({!.IO.e}).any;
+        if ($asset-dir-missing and $v) {
+            note qq:to/END/;
+                (warning) one of the following directories cannot be found:
+
+                    @default-asset-dirs.join(', ')
+
+                You can get the defaults by executing:
 
                     documentable setup
                 END

--- a/t/101-cli.t
+++ b/t/101-cli.t
@@ -11,7 +11,7 @@ subtest 'no arguments provided' => {
 
 subtest 'setup assets' => {
     lives-ok {Documentable::CLI::MAIN('setup', :o)}, "Setup lives";
-    my @dirs = ("assets", "templates", "html", "highlights");
+    my @dirs = ("assets", "template", "html", "highlights");
     for @dirs -> $dir {
         ok $dir.IO.e, "$dir directory created";
     }


### PR DESCRIPTION
The name of the `template` directory was changed to `templates` in
44e524d, which was incorrect as discussed in #120.  This commit fixes
issue #120 by using the singular form for this directory name and hence
fixes the test error being seen in `t/101-cli.t`.