### PR TITLE
fix running workflows with act

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,6 @@ assets
 assets/*
 html
 html/*
-highlights
-highlights/*
 package-lock.json
 *.epub
 .vscode
@@ -76,5 +74,4 @@ app-start
 Makefile
 .cache-*
 .t
-.*
 *.iml

--- a/production.Dockerfile
+++ b/production.Dockerfile
@@ -4,6 +4,8 @@ LABEL version="1.0.0" maintainer="Antonio Gamiz <antoniogamiz10@gmail.com>"
 
 ARG branch_name=master
 
+RUN apk add --no-cache bash
+
 RUN git clone -b $branch_name --single-branch https://github.com/Raku/Documentable.git \
     && cd Documentable \
     && zef install --deps-only --/test . \


### PR DESCRIPTION
This solves nektos/act#310 and allows the most of the workflow to complete with `act`. There's still something blocking the `build-documentation` step however that is outside my expertise but it appears to involve either `JamesIves/github-pages-deploy-action`'s or `actions/io`'s interaction with `act`.