### PR TITLE
Allows for later versions of Pod::To::HTML

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -14,7 +14,7 @@
   "auth": "github:Raku",
   "depends": [
     "Pod::Load:ver<0.5.4>",
-    "Pod::To::HTML:ver<0.7.1>",
+    "Pod::To::HTML:ver<0.7.1+>",
     "Pod::From::Cache:ver<0.2>",
     "Perl6::TypeGraph:ver<2.1.3>:auth<github:antoniogamiz>:api<2>",
     "Pod::Utilities:ver<0.0.1>",


### PR DESCRIPTION
Fix for zef not finding proper Pod::To::HTML module